### PR TITLE
Json serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,4 +164,4 @@ Quit the game using `quit`, `q`, or `ctrl-d`.
 
 ### Seeing the game state
 
-The only undocumented command is `_state` (new in v0.0.2).  Use it to see a JSON representation of the game state.
+The only undocumented command is `_dump` (formerly `_state`).  Use it to see a JSON representation of the game state.

--- a/pytience/cards/deck.py
+++ b/pytience/cards/deck.py
@@ -77,31 +77,33 @@ class Card:
         self.is_revealed = False
         return self
 
-    def __repr__(self):
-        if self.pip is None:
-            return '*'
-        else:
-            return '{}{}{}'.format('|' if self.is_concealed else '', self.pip.value, self.suit.value)
-
     def __str__(self):
-        if self.is_concealed:
-            return '#'
-        return repr(self)
+        state = '|' if self.is_concealed else ''
+        if self.pip is None:
+            return '{}*'.format(state)
+        else:
+            return '{}{}{}'.format(state, self.pip.value, self.suit.value)
 
     @classmethod
     def parse_card(cls, card_string) -> 'Card':
         """
-        Converts a card string, e.g. "10♣" to a Card(Pip.Ten, Suit.Cubs)
+        Converts a card string, e.g. "10♣" to a Card(Pip.Ten, Suit.Clubs)
         :param card_string: The string representing the card
         :return: new Card object
         """
-        suit = Suit(card_string[-1])
+
+        is_revealed = True
         if card_string[0] == '|':
-            pip = Pip(card_string[1:-1])
-            return Card(pip, suit)
+            is_revealed = False
+            card_string = card_string[1:]
+
+        if card_string == '*':
+            pip, suit = None, None
         else:
-            pip = Pip(card_string[:-1])
-            return Card(pip, suit).reveal()
+            pip = Pip(card_string[:-1]) or None
+            suit = Suit(card_string[-1]) or None
+
+        return Card(pip, suit, is_revealed)
 
 
 class Deck:

--- a/pytience/cards/deck.py
+++ b/pytience/cards/deck.py
@@ -136,7 +136,7 @@ class Deck:
             raise NoCardsRemainingException("No cards remaining in the deck.")
         return self.cards.popleft()
 
-    def deal_all(self) -> Card:
+    def deal_all(self) -> Iterable[Card]:
         """Deal all the cards"""
         while len(self.cards) > 0:
             yield self.cards.popleft()

--- a/pytience/cards/deck.py
+++ b/pytience/cards/deck.py
@@ -111,14 +111,17 @@ class Card:
 
 
 class Deck:
-    def __init__(self, num_decks: int = 1, num_jokers_per_deck: int = 0):
-        self.num_decks = num_decks
-        self.num_jokers = num_jokers_per_deck
-        self.cards = deque(
-            [Card(pip, suit) for suit, pip in product(Suit, Pip)] * num_decks +
-            [Card(None, None)] * num_jokers_per_deck * num_decks
-        )
-        self.is_shuffled = False
+    def __init__(self, num_decks: int = 1, num_jokers_per_deck: int = 0, deck_dump: object = None):
+        if deck_dump:
+            self.load(deck_dump)
+        else:
+            self.num_decks = num_decks
+            self.num_jokers = num_jokers_per_deck
+            self.cards = deque(
+                [Card(pip, suit) for suit, pip in product(Suit, Pip)] * num_decks +
+                [Card(None, None)] * num_jokers_per_deck * num_decks
+            )
+            self.is_shuffled = False
 
     def shuffle(self):
         """Ensure the deck is shuffled"""
@@ -159,6 +162,12 @@ class Deck:
             "is_shuffled": self.is_shuffled,
             "cards": list(map(str, self.cards))
         }
+
+    def load(self, deck_dump: object):
+        self.num_decks = deck_dump["num_decks"]
+        self.num_jokers = deck_dump["num_jokers"]
+        self.is_shuffled = deck_dump["is_shuffled"]
+        self.cards = deque([Card.parse_card(card_string) for card_string in deck_dump["cards"]])
 
     def __len__(self):
         return self.remaining

--- a/pytience/cards/deck.py
+++ b/pytience/cards/deck.py
@@ -77,6 +77,9 @@ class Card:
         self.is_revealed = False
         return self
 
+    def __repr__(self):
+        return self.__str__()
+
     def __str__(self):
         state = '|' if self.is_concealed else ''
         if self.pip is None:

--- a/pytience/cards/deck.py
+++ b/pytience/cards/deck.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 import random
-from itertools import product
 from collections import deque
 from dataclasses import dataclass
 from enum import Enum
-from typing import Iterable, NoReturn
+from itertools import product
+from typing import Iterable
+
 from pytience.cards.exception import NoCardsRemainingException
 
 
@@ -150,6 +151,14 @@ class Deck:
         """Add a list of cards to the bottom of the deck"""
         self.cards.extend(cards)
         return self
+
+    def dump(self):
+        return {
+            "num_decks": self.num_decks,
+            "num_jokers": self.num_jokers,
+            "is_shuffled": self.is_shuffled,
+            "cards": list(map(str, self.cards))
+        }
 
     def __len__(self):
         return self.remaining

--- a/pytience/cmd/klondike.py
+++ b/pytience/cmd/klondike.py
@@ -204,12 +204,13 @@ class KlondikeCmd(Cmd):
                                      Style.RESET_ALL)
 
         def _paint_card(_card: Card, left_pad: int = 0, right_pad: int = 0):
-            length = len(str(_card))
+            card_string = '#' if _card.is_concealed else str(_card)
+            length = len(card_string)
             left = ' ' * (left_pad - length)
             right = ' ' * (right_pad - length - len(left))
 
             if _card.is_concealed or _card.pip is None:
-                return '{}{}{}{}{}'.format(left, Style.BRIGHT, str(_card), Style.RESET_ALL, right)
+                return '{}{}{}{}{}'.format(left, Style.BRIGHT, str(card_string), Style.RESET_ALL, right)
 
             return '{}{}{}{}{}{}'.format(left, Style.BRIGHT, _card.pip.value, _paint_suit(_card.suit), Style.RESET_ALL,
                                          right)

--- a/pytience/cmd/klondike.py
+++ b/pytience/cmd/klondike.py
@@ -5,7 +5,6 @@ from itertools import zip_longest
 from pathlib import Path
 import json
 
-import dill
 from colorama import Style, Fore, Back
 
 from pytience.cards.deck import Card, Suit, Color
@@ -146,8 +145,8 @@ class KlondikeCmd(Cmd):
         # TODO: change serialization to JSON
         DEFAULT_SAVE_FILE.parent.mkdir(parents=True, exist_ok=True)
         filename = filename or DEFAULT_SAVE_FILE
-        with open(filename, 'wb') as f:
-            dill.dump(klondike, f)
+        with open(filename, 'w') as f:
+            json.dump(klondike.dump(), f)
 
     @error_handler
     def do_save(self, line):
@@ -159,8 +158,9 @@ class KlondikeCmd(Cmd):
     def load(filename=None):
         # TODO: change serialization to JSON
         filename = filename or DEFAULT_SAVE_FILE
-        with open(filename, 'rb') as f:
-            return dill.load(f)
+        with open(filename, 'r') as f:
+            game_dump = json.load(f)
+            return KlondikeGame(game_dump=game_dump)
 
     @error_handler
     def do_load(self, line):

--- a/pytience/cmd/klondike.py
+++ b/pytience/cmd/klondike.py
@@ -174,9 +174,9 @@ class KlondikeCmd(Cmd):
 
     def default(self, line):
         cmd, arg, line = self.parseline(line)
-        if cmd == "_state":
+        if cmd == "_dump":
             print("\033[H\033[J")  # Clear screen
-            self.print_state()
+            self.print_dump()
             print("Press return to continue...")
             try:
                 input()
@@ -195,8 +195,8 @@ class KlondikeCmd(Cmd):
         else:
             self.errors.append(Exception("*** Unknown syntax: {} ***".format(line)))
 
-    def print_state(self):
-        print(json.dumps(self.klondike.state, indent=2, ensure_ascii=False))
+    def print_dump(self):
+        print(json.dumps(self.klondike.dump(), indent=2, ensure_ascii=False))
 
     def print_game(self):
         def _paint_suit(_suit):

--- a/pytience/games/solitaire/foundation.py
+++ b/pytience/games/solitaire/foundation.py
@@ -58,3 +58,9 @@ class Foundation(Undoable):
     @property
     def is_full(self) -> bool:
         return all(len(pile) == 13 for pile in list(self.piles.values()))
+
+    def dump(self):
+        return {
+                "piles": {str(suit): list(map(str, pile)) for suit, pile in self.piles.items()},
+                "undo_stack": self.dump_undo_stack()
+            }

--- a/pytience/games/solitaire/foundation.py
+++ b/pytience/games/solitaire/foundation.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from functools import partial
 from typing import Dict, List, Iterable, Union, Type
 
 from pytience.cards.deck import Suit, Card, Pip
@@ -7,7 +6,7 @@ from pytience.cards.exception import NoCardsRemainingException
 from pytience.games.solitaire import CARD_VALUES
 from pytience.games.solitaire.exception import ConcealedCardNotAllowedException, NoSuchSuitException, \
     IllegalFoundationBuildOrderException
-from pytience.games.util import Undoable
+from pytience.games.util import Undoable, UndoAction
 
 
 # TODO: make more specific exceptions so that error conditions can be less ambiguous
@@ -32,7 +31,7 @@ class Foundation(Undoable):
 
         card = pile.pop()
         self.undo_stack.append([
-            partial(self.undo_get, str(suit), str(card))
+            UndoAction(self.undo_get, [str(suit), str(card)])
         ])
         return card
 
@@ -48,7 +47,7 @@ class Foundation(Undoable):
         pile = self.piles[card.suit]
         if card.pip == Pip.Ace:
             pile.append(card)
-            undo_log.append(partial(self.undo_put, str(card.suit)))
+            undo_log.append(UndoAction(self.undo_put, [str(card.suit)]))
         elif not pile:
             raise IllegalFoundationBuildOrderException('Foundation cards must be built sequentially per suit.')
         else:
@@ -57,7 +56,7 @@ class Foundation(Undoable):
             if value != top_value + 1:
                 raise IllegalFoundationBuildOrderException('Foundation cards must be build sequentially per suit.')
             pile.append(card)
-            undo_log.append(partial(self.undo_put, str(card.suit)))
+            undo_log.append(UndoAction(self.undo_put, [str(card.suit)]))
         if undo_log:
             self.undo_stack.append(undo_log)
 

--- a/pytience/games/solitaire/foundation.py
+++ b/pytience/games/solitaire/foundation.py
@@ -30,9 +30,7 @@ class Foundation(Undoable):
             raise NoCardsRemainingException('No foundation cards for suit {}'.format(suit))
 
         card = pile.pop()
-        self.undo_stack.append([
-            UndoAction(self.undo_get, [str(suit), str(card)])
-        ])
+        self.undo_stack.append(UndoAction(self.undo_get, [str(suit), str(card)]))
         return card
 
     def undo_put(self, suit: str):
@@ -41,13 +39,12 @@ class Foundation(Undoable):
         pile.pop()
 
     def put(self, card: Card):
-        undo_log = []
         if card.is_concealed:
             raise ConcealedCardNotAllowedException('Foundation cards must be revealed')
         pile = self.piles[card.suit]
         if card.pip == Pip.Ace:
             pile.append(card)
-            undo_log.append(UndoAction(self.undo_put, [str(card.suit)]))
+            self.undo_stack.append(UndoAction(self.undo_put, [str(card.suit)]))
         elif not pile:
             raise IllegalFoundationBuildOrderException('Foundation cards must be built sequentially per suit.')
         else:
@@ -56,9 +53,7 @@ class Foundation(Undoable):
             if value != top_value + 1:
                 raise IllegalFoundationBuildOrderException('Foundation cards must be build sequentially per suit.')
             pile.append(card)
-            undo_log.append(UndoAction(self.undo_put, [str(card.suit)]))
-        if undo_log:
-            self.undo_stack.append(undo_log)
+            self.undo_stack.append(UndoAction(self.undo_put, [str(card.suit)]))
 
     @property
     def is_full(self) -> bool:

--- a/pytience/games/solitaire/klondike.py
+++ b/pytience/games/solitaire/klondike.py
@@ -198,27 +198,12 @@ class KlondikeGame(Undoable):
         if not self.is_solved():
             self.seek_tableau_to_foundation()
 
-    @property
-    def state(self):
+    def dump(self):
         return {
             "score": self.score,
-            "stock": {
-                "num_decks": self.stock.num_decks,
-                "num_jokers": self.stock.num_jokers,
-                "is_shuffled": self.stock.is_shuffled,
-                "cards": list(map(str, self.stock.cards))
-            },
+            "stock": self.stock.dump(),
             "waste": list(map(str, self.waste)),
-            "foundation": {
-                "piles": {str(suit): list(map(str, pile)) for suit, pile in self.foundation.piles.items()},
-                "undo_stack": self.foundation.export_undo_stack()
-            },
-            "tableau": {
-                "piles": [
-                    list(map(str, pile))
-                    for pile in self.tableau.piles
-                ],
-                "undo_stack": self.tableau.export_undo_stack()
-            },
-            "undo_stack": self.export_undo_stack()
+            "foundation": self.foundation.dump(),
+            "tableau": self.tableau.dump(),
+            "undo_stack": self.dump_undo_stack()
         }

--- a/pytience/games/solitaire/klondike.py
+++ b/pytience/games/solitaire/klondike.py
@@ -39,7 +39,7 @@ class KlondikeGame(Undoable):
                 replenished = True  # we need to know this for the undo event
         try:
             self.waste.append(self.stock.deal().reveal())
-            self.undo_stack.append([UndoAction(self.undo_deal, [replenished])])
+            self.undo_stack.append(UndoAction(self.undo_deal, [replenished]))
         except NoCardsRemainingException:
             raise IllegalMoveException('No cards left in the stock or waste')
 
@@ -59,7 +59,7 @@ class KlondikeGame(Undoable):
             try:
                 self.tableau.put([card], pile_num)
                 self.adjust_score(-POINTS_TABLEAU_FOUNDATION)
-                self.undo_stack.append([UndoAction(self.undo_select_foundation)])
+                self.undo_stack.append(UndoAction(self.undo_select_foundation))
                 return
             except TableauPileIndexError as e:
                 self.foundation.undo()
@@ -89,7 +89,7 @@ class KlondikeGame(Undoable):
             try:
                 self.foundation.put(card)
                 self.adjust_score(POINTS_WASTE_FOUNDATION)
-                self.undo_stack.append([UndoAction(self.undo_select_waste, [True, str(card)])])
+                self.undo_stack.append(UndoAction(self.undo_select_waste, [True, str(card)]))
                 return
             except IllegalFoundationMoveException:
                 pass
@@ -99,7 +99,7 @@ class KlondikeGame(Undoable):
             try:
                 self.tableau.put([card], pile_num)
                 self.adjust_score(POINTS_WASTE_TABLEAU)
-                self.undo_stack.append([UndoAction(self.undo_select_waste, [False, str(card)])])
+                self.undo_stack.append(UndoAction(self.undo_select_waste, [False, str(card)]))
                 return
             except IllegalTableauMoveException:
                 pass
@@ -123,7 +123,7 @@ class KlondikeGame(Undoable):
                 cards = self.tableau.get(_pile_num, -1)
                 self.foundation.put(cards[0])
                 self.score += POINTS_TABLEAU_FOUNDATION
-                self.undo_stack.append([UndoAction(self.undo_seek_tableau_to_foundation)])
+                self.undo_stack.append(UndoAction(self.undo_seek_tableau_to_foundation))
                 return
             except IllegalTableauMoveException:
                 # The chosen pile has no cards.  No tableau undo needed.
@@ -158,7 +158,7 @@ class KlondikeGame(Undoable):
                 try:
                     self.foundation.put(cards[0])
                     self.score += POINTS_TABLEAU_FOUNDATION
-                    self.undo_stack.append([UndoAction(self.undo_select_tableau, [True])])
+                    self.undo_stack.append(UndoAction(self.undo_select_tableau, [True]))
                     return
                 except IllegalFoundationMoveException:
                     pass  # Don't undo the tableau get because we need to search for another tableau destination now
@@ -169,7 +169,7 @@ class KlondikeGame(Undoable):
                 if pile_num != destination:
                     try:
                         self.tableau.put(cards, destination)
-                        self.undo_stack.append([UndoAction(self.undo_select_tableau, [False])])
+                        self.undo_stack.append(UndoAction(self.undo_select_tableau, [False]))
                         return
                     except IllegalTableauMoveException:
                         pass

--- a/pytience/games/solitaire/klondike.py
+++ b/pytience/games/solitaire/klondike.py
@@ -71,6 +71,15 @@ class KlondikeGame(Undoable):
         self.foundation.undo()
         raise IllegalMoveException('No tableau fit for {}'.format(str(card)))
 
+    def undo_select_waste(self, undo_foundation: bool, card_string: str):
+        if undo_foundation:
+            self.adjust_score(-POINTS_WASTE_FOUNDATION)
+            self.foundation.undo()
+        else:
+            self.adjust_score(-POINTS_WASTE_TABLEAU)
+            self.tableau.undo()
+        self.waste.append(Card.parse_card(card_string))
+
     def select_waste(self, tableau_destination_pile: int = None):
         """Try to find the best fit for the top waste card"""
 
@@ -81,11 +90,7 @@ class KlondikeGame(Undoable):
             try:
                 self.foundation.put(card)
                 self.adjust_score(POINTS_WASTE_FOUNDATION)
-                self.undo_stack.append([
-                    partial(self.waste.append, card),
-                    partial(self.foundation.undo),
-                    partial(self.adjust_score, -POINTS_WASTE_FOUNDATION)
-                ])
+                self.undo_stack.append([partial(self.undo_select_waste, True, str(card))])
                 return
             except IllegalFoundationMoveException:
                 pass
@@ -95,11 +100,7 @@ class KlondikeGame(Undoable):
             try:
                 self.tableau.put([card], pile_num)
                 self.adjust_score(POINTS_WASTE_TABLEAU)
-                self.undo_stack.append([
-                    partial(self.waste.append, card),
-                    partial(self.tableau.undo),
-                    partial(self.adjust_score, -POINTS_WASTE_TABLEAU)
-                ])
+                self.undo_stack.append([partial(self.undo_select_waste, False, str(card))])
                 return
             except IllegalTableauMoveException:
                 pass

--- a/pytience/games/solitaire/klondike.py
+++ b/pytience/games/solitaire/klondike.py
@@ -14,14 +14,16 @@ POINTS_TABLEAU_FOUNDATION = 15
 
 
 class KlondikeGame(Undoable):
-    def __init__(self):
-        self.stock: Deck = Deck().shuffle()
-        self.tableau: Tableau = Tableau(7, self.stock)
-        self.waste: List[Card] = []
-        self.score = 0
-        super().__init__()
-
-        self.foundation = Foundation(suits=Suit)
+    def __init__(self, game_dump: object = None):
+        if game_dump:
+            self.load(game_dump)
+        else:
+            self.stock: Deck = Deck().shuffle()
+            self.tableau: Tableau = Tableau(7, self.stock)
+            self.waste: List[Card] = []
+            self.score = 0
+            self.foundation = Foundation(suits=Suit)
+            super().__init__()
 
     def undo_deal(self, undo_replenish: bool):
         self.stock.undeal(self.waste.pop().conceal())
@@ -198,7 +200,7 @@ class KlondikeGame(Undoable):
         if not self.is_solved():
             self.seek_tableau_to_foundation()
 
-    def dump(self):
+    def dump(self) -> object:
         return {
             "score": self.score,
             "stock": self.stock.dump(),
@@ -207,3 +209,11 @@ class KlondikeGame(Undoable):
             "tableau": self.tableau.dump(),
             "undo_stack": self.dump_undo_stack()
         }
+
+    def load(self, game_dump: object) -> NoReturn:
+        self.score = game_dump.get("score", 0)
+        self.stock = Deck(deck_dump=game_dump.get("stock", dict()))
+        self.waste = list(map(Card.parse_card, game_dump.get("waste", list())))
+        self.foundation = Foundation(foundation_dump=game_dump.get("foundation", dict()))
+        self.tableau = Tableau(tableau_dump=game_dump.get("tableau", dict()))
+        self.load_undo_stack(game_dump.get("undo_stack", list()))

--- a/pytience/games/solitaire/klondike.py
+++ b/pytience/games/solitaire/klondike.py
@@ -47,6 +47,11 @@ class KlondikeGame(Undoable):
     def adjust_score(self, points: int):
         self.score += points
 
+    def undo_select_foundation(self):
+        self.adjust_score(POINTS_TABLEAU_FOUNDATION)
+        self.tableau.undo()
+        self.foundation.undo()
+
     def select_foundation(self, suit: Suit, tableau_destination_pile: int = None):
         card = self.foundation.get(suit)
 
@@ -55,11 +60,7 @@ class KlondikeGame(Undoable):
             try:
                 self.tableau.put([card], pile_num)
                 self.adjust_score(-POINTS_TABLEAU_FOUNDATION)
-                self.undo_stack.append([
-                    partial(self.foundation.undo),
-                    partial(self.tableau.undo),
-                    partial(self.adjust_score, POINTS_TABLEAU_FOUNDATION)
-                ])
+                self.undo_stack.append([partial(self.undo_select_foundation)])
                 return
             except TableauPileIndexError as e:
                 self.foundation.undo()

--- a/pytience/games/solitaire/klondike.py
+++ b/pytience/games/solitaire/klondike.py
@@ -207,18 +207,19 @@ class KlondikeGame(Undoable):
                 "num_decks": self.stock.num_decks,
                 "num_jokers": self.stock.num_jokers,
                 "is_shuffled": self.stock.is_shuffled,
-                "cards": list(map(repr, self.stock.cards))
+                "cards": list(map(str, self.stock.cards))
             },
             "waste": list(map(str, self.waste)),
             "foundation": {
-                "piles": {str(suit): list(map(repr, pile)) for suit, pile in self.foundation.piles.items()},
-                "undo_stack": None  # TODO: implement undo_stack serialization
+                "piles": {str(suit): list(map(str, pile)) for suit, pile in self.foundation.piles.items()},
+                "undo_stack": self.foundation.export_undo_stack()
             },
             "tableau": {
                 "piles": [
-                    list(map(repr, pile))
+                    list(map(str, pile))
                     for pile in self.tableau.piles
                 ],
-                "undo_stack": None  # TODO: implement undo_stack serialization
-            }
+                "undo_stack": self.tableau.export_undo_stack()
+            },
+            "undo_stack": self.export_undo_stack()
         }

--- a/pytience/games/solitaire/klondike.py
+++ b/pytience/games/solitaire/klondike.py
@@ -136,7 +136,7 @@ class KlondikeGame(Undoable):
     def undo_select_tableau(self, undo_foundation: bool):
         if undo_foundation:
             self.adjust_score(-POINTS_TABLEAU_FOUNDATION)
-            self.foundation.undo
+            self.foundation.undo()
         else:
             self.tableau.undo()
         self.tableau.undo()

--- a/pytience/games/solitaire/tableau.py
+++ b/pytience/games/solitaire/tableau.py
@@ -1,11 +1,10 @@
-from functools import partial
 from typing import List, NoReturn
 
 from pytience.cards.deck import Deck, Card, Pip
 from pytience.games.solitaire import CARD_VALUES
 from pytience.games.solitaire.exception import TableauCardIndexError, TableauPileIndexError, \
     TableauCardNotAvailableException, IllegalTableauBuildOrderException, ConcealedCardNotAllowedException
-from pytience.games.util import Undoable
+from pytience.games.util import Undoable, UndoAction
 
 
 class Tableau(Undoable):
@@ -37,7 +36,7 @@ class Tableau(Undoable):
         if not pile:
             if cards[0].pip == Pip.King:
                 pile.extend(cards)
-                self.undo_stack.append([partial(self.undo_put, pile_num, len(cards))])
+                self.undo_stack.append([UndoAction(self.undo_put, [pile_num, len(cards)])])
                 return
             else:
                 raise IllegalTableauBuildOrderException('Only Kings may be built on empty tableau piles.')
@@ -46,7 +45,7 @@ class Tableau(Undoable):
                 'Tableau cards must be built in descending order with alternate colors')
         else:
             pile.extend(cards)
-            self.undo_stack.append([partial(self.undo_put, pile_num, len(cards))])
+            self.undo_stack.append([UndoAction(self.undo_put, [pile_num, len(cards)])])
 
     def undo_get(self, pile_num: int, card_strings: List[str], re_conceal: bool):
         if re_conceal:
@@ -70,7 +69,7 @@ class Tableau(Undoable):
         for _ in range(len(cards)):
             pile.pop()
         revealed = self._reveal(pile_num)
-        self.undo_stack.append([partial(self.undo_get, pile_num, list(map(str, cards)), revealed)])
+        self.undo_stack.append([UndoAction(self.undo_get, [pile_num, list(map(str, cards)), revealed])])
         return cards
 
     def _reveal(self, pile_num: int) -> bool:

--- a/pytience/games/solitaire/tableau.py
+++ b/pytience/games/solitaire/tableau.py
@@ -36,7 +36,7 @@ class Tableau(Undoable):
         if not pile:
             if cards[0].pip == Pip.King:
                 pile.extend(cards)
-                self.undo_stack.append([UndoAction(self.undo_put, [pile_num, len(cards)])])
+                self.undo_stack.append(UndoAction(self.undo_put, [pile_num, len(cards)]))
                 return
             else:
                 raise IllegalTableauBuildOrderException('Only Kings may be built on empty tableau piles.')
@@ -45,7 +45,7 @@ class Tableau(Undoable):
                 'Tableau cards must be built in descending order with alternate colors')
         else:
             pile.extend(cards)
-            self.undo_stack.append([UndoAction(self.undo_put, [pile_num, len(cards)])])
+            self.undo_stack.append(UndoAction(self.undo_put, [pile_num, len(cards)]))
 
     def undo_get(self, pile_num: int, card_strings: List[str], re_conceal: bool):
         if re_conceal:
@@ -69,7 +69,7 @@ class Tableau(Undoable):
         for _ in range(len(cards)):
             pile.pop()
         revealed = self._reveal(pile_num)
-        self.undo_stack.append([UndoAction(self.undo_get, [pile_num, list(map(str, cards)), revealed])])
+        self.undo_stack.append(UndoAction(self.undo_get, [pile_num, list(map(str, cards)), revealed]))
         return cards
 
     def _reveal(self, pile_num: int) -> bool:

--- a/pytience/games/solitaire/tableau.py
+++ b/pytience/games/solitaire/tableau.py
@@ -100,6 +100,15 @@ class Tableau(Undoable):
         else:
             return False
 
+    def dump(self):
+        return {
+                "piles": [
+                    list(map(str, pile))
+                    for pile in self.piles
+                ],
+                "undo_stack": self.dump_undo_stack()
+            }
+
     def __repr__(self):
         return str([len(p) for p in self.piles])
 

--- a/pytience/games/util.py
+++ b/pytience/games/util.py
@@ -37,6 +37,6 @@ class Undoable:
         Turn a list of lists of serialized functions from `export_undo_stack` into partials.
         Since the function_names are relative to self, care must be made not to create UndoActions with
         function calls outside the current class
-        :param undo_stack: A list of lists of
+        :param undo_stack: A list of serialized UndoAction object from dump_undo_stack()
         """
         self.undo_stack = [UndoAction(getattr(self, action['action']), *action['args']) for action in undo_stack]

--- a/pytience/games/util.py
+++ b/pytience/games/util.py
@@ -39,4 +39,4 @@ class Undoable:
         function calls outside the current class
         :param undo_stack: A list of serialized UndoAction object from dump_undo_stack()
         """
-        self.undo_stack = [UndoAction(getattr(self, action['action']), *action['args']) for action in undo_stack]
+        self.undo_stack = [UndoAction(getattr(self, action['action']), action['args']) for action in undo_stack]

--- a/pytience/games/util.py
+++ b/pytience/games/util.py
@@ -16,15 +16,13 @@ class UndoAction:
 
 class Undoable:
     def __init__(self):
-        self.undo_stack: List[List[Callable]] = []
+        self.undo_stack: List[Callable] = []
 
     def undo(self) -> NoReturn:
         """Undo the last event on the undo stack"""
         if self.undo_stack:
-            action_stack = self.undo_stack.pop()
-            while action_stack:
-                undo_action = action_stack.pop()
-                undo_action()
+            undo_action = self.undo_stack.pop()
+            undo_action()
 
     def export_undo_stack(self) -> object:
         """
@@ -32,20 +30,13 @@ class Undoable:
         function names and args instead of partials
         :return: A language-agnostic object representing the undo stack
         """
-        return [
-            [action.dump() for action in actions]
-            for actions in self.undo_stack
-        ]
+        return [action.dump() for action in self.undo_stack]
 
     def import_undo_stack(self, undo_stack) -> NoReturn:
         """
         Turn a list of lists of serialized functions from `export_undo_stack` into partials.
-        Since the function_names are relative to self, care must be made not to
+        Since the function_names are relative to self, care must be made not to create UndoActions with
+        function calls outside the current class
         :param undo_stack: A list of lists of
         """
-        self.undo_stack = [
-            [
-                UndoAction(getattr(self, action['action']), *action['args']) for action in actions
-            ]
-            for actions in undo_stack
-        ]
+        self.undo_stack = [UndoAction(getattr(self, action['action']), *action['args']) for action in undo_stack]

--- a/pytience/games/util.py
+++ b/pytience/games/util.py
@@ -8,7 +8,7 @@ class UndoAction:
     args: List[Any] = field(default_factory=list)
 
     def dump(self):
-        return {'function_name': self.function.__name__, 'args': self.args}
+        return {'action': self.function.__name__, 'args': self.args}
 
     def __call__(self, *_, **__):
         self.function(*self.args)
@@ -45,7 +45,7 @@ class Undoable:
         """
         self.undo_stack = [
             [
-                UndoAction(getattr(self, action['function_name']), *action['args']) for action in actions
+                UndoAction(getattr(self, action['action']), *action['args']) for action in actions
             ]
             for actions in undo_stack
         ]

--- a/pytience/games/util.py
+++ b/pytience/games/util.py
@@ -1,5 +1,4 @@
 from typing import List, Callable, NoReturn, Any
-from functools import partial
 from dataclasses import dataclass, field
 
 
@@ -8,7 +7,7 @@ class UndoAction:
     function: Callable
     args: List[Any] = field(default_factory=list)
 
-    def __repr__(self):
+    def dump(self):
         return {'function_name': self.function.__name__, 'args': self.args}
 
     def __call__(self, *_, **__):
@@ -34,7 +33,7 @@ class Undoable:
         :return: A language-agnostic object representing the undo stack
         """
         return [
-            [{'function_name': action.func.__name__, 'args': action.args} for action in actions]
+            [action.dump() for action in actions]
             for actions in self.undo_stack
         ]
 
@@ -46,7 +45,7 @@ class Undoable:
         """
         self.undo_stack = [
             [
-                partial(getattr(self, action['function_name']), *action['args']) for action in actions
+                UndoAction(getattr(self, action['function_name']), *action['args']) for action in actions
             ]
             for actions in undo_stack
         ]

--- a/pytience/games/util.py
+++ b/pytience/games/util.py
@@ -24,7 +24,7 @@ class Undoable:
             undo_action = self.undo_stack.pop()
             undo_action()
 
-    def export_undo_stack(self) -> object:
+    def dump_undo_stack(self) -> object:
         """
         Creates a serialization-friendly representation of the undo stack using
         function names and args instead of partials
@@ -32,7 +32,7 @@ class Undoable:
         """
         return [action.dump() for action in self.undo_stack]
 
-    def import_undo_stack(self, undo_stack) -> NoReturn:
+    def load_undo_stack(self, undo_stack) -> NoReturn:
         """
         Turn a list of lists of serialized functions from `export_undo_stack` into partials.
         Since the function_names are relative to self, care must be made not to create UndoActions with

--- a/pytience/games/util.py
+++ b/pytience/games/util.py
@@ -1,14 +1,39 @@
 from typing import List, Callable, NoReturn
+from functools import partial
 
 
-class Undoable:  # pylint: disable=too-few-public-methods
+class Undoable:
     def __init__(self):
         self.undo_stack: List[List[Callable]] = []
 
     def undo(self) -> NoReturn:
-        """Undo the last action on the undo stack"""
+        """Undo the last event on the undo stack"""
         if self.undo_stack:
-            function_stack = self.undo_stack.pop()
-            while function_stack:
-                undo_function = function_stack.pop()
-                undo_function()
+            action_stack = self.undo_stack.pop()
+            while action_stack:
+                undo_action = action_stack.pop()
+                undo_action()
+
+    def export_undo_stack(self) -> object:
+        """
+        Creates a serialization-friendly representation of the undo stack using
+        function names and args instead of partials
+        :return: A language-agnostic object representing the undo stack
+        """
+        return [
+            [{'function_name': action.func.__name__, 'args': action.args} for action in actions]
+            for actions in self.undo_stack
+        ]
+
+    def import_undo_stack(self, undo_stack) -> NoReturn:
+        """
+        Turn a list of lists of serialized functions from `export_undo_stack` into partials.
+        Since the function_names are relative to self, care must be made not to
+        :param undo_stack: A list of lists of
+        """
+        self.undo_stack = [
+            [
+                partial(getattr(self, action['function_name']), *action['args']) for action in actions
+            ]
+            for actions in undo_stack
+        ]

--- a/pytience/games/util.py
+++ b/pytience/games/util.py
@@ -1,5 +1,18 @@
-from typing import List, Callable, NoReturn
+from typing import List, Callable, NoReturn, Any
 from functools import partial
+from dataclasses import dataclass, field
+
+
+@dataclass
+class UndoAction:
+    function: Callable
+    args: List[Any] = field(default_factory=list)
+
+    def __repr__(self):
+        return {'function_name': self.function.__name__, 'args': self.args}
+
+    def __call__(self, *_, **__):
+        self.function(*self.args)
 
 
 class Undoable:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 colorama==0.4.3
-dill==0.3.1.1
 pyreadline==2.1

--- a/test/test_deck.py
+++ b/test/test_deck.py
@@ -152,8 +152,34 @@ class DeckTestCase(TestCase):
         self.assertEqual(str(Pip.King), 'K')
 
     def test_parse_card(self):
-        for (suit, pip) in product(Suit, Pip):
-            card_string = '{}{}'.format(pip.value, suit.value)
+        for (suit, pip, revealed) in product(Suit, Pip, [True, False]):
+            card_string = '{}{}{}'.format('|' if not revealed else '', pip.value, suit.value)
             card = Card.parse_card(card_string)
             self.assertEqual(card.pip, pip, "The parsed card should have the correct pip.")
             self.assertEqual(card.suit, suit, "The parsed card should have the correct suit.")
+            self.assertEqual(card.is_revealed, revealed, "The parsed card should have the correct reveal state.")
+        for revealed in (True, False):
+            card = Card.parse_card('{}*'.format('|' if not revealed else ''))
+            self.assertIsNone(card.pip, "Joker should have no pip")
+            self.assertIsNone(card.suit, "Joker should have no suit")
+            self.assertEqual(card.is_revealed, revealed, "The parsed card should have the correct reveal state.")
+
+    def test_dump(self):
+        deck = Deck().shuffle()
+        cards = list(map(str, deck.cards))
+        dump = deck.dump()
+        self.assertListEqual(cards, dump["cards"])
+        self.assertEqual(deck.num_decks, dump["num_decks"])
+        self.assertEqual(deck.num_jokers, dump["num_jokers"])
+        self.assertEqual(deck.is_shuffled, dump["is_shuffled"])
+
+    def test_load(self):
+        # TODO move this to an external fixture
+        dump = {"num_decks": 1, "num_jokers": 0, "is_shuffled": True,
+                "cards": ["|10♠", "|4♦", "|4♠", "|J♥", "|2♥", "|7♥", "|5♥", "|A♠", "|5♣", "|Q♠", "|J♠", "|Q♣", "|9♠"]}
+        deck = Deck(deck_dump=dump)
+        self.assertListEqual(list(map(str, deck.cards)), dump["cards"])
+        self.assertEqual(deck.num_decks, dump["num_decks"])
+        self.assertEqual(deck.num_jokers, dump["num_jokers"])
+        self.assertEqual(deck.is_shuffled, dump["is_shuffled"])
+

--- a/test/test_deck.py
+++ b/test/test_deck.py
@@ -27,7 +27,7 @@ class DeckTestCase(TestCase):
             self.assertFalse(card.is_revealed)
             self.assertTrue(card.is_concealed)
             self.assertIsNotNone(concealed, "Card conceal should return itself.")
-            self.assertEqual(len(str(card)), 1, "Concealed card string should always be 1 char.")
+            # self.assertEqual(len(str(card)), 1, "Concealed card string should always be 1 char.")
             card.reveal()
             self.assertTrue(card.is_revealed)
             self.assertFalse(card.is_concealed)

--- a/test/test_foundation.py
+++ b/test/test_foundation.py
@@ -90,6 +90,47 @@ class FoundationTestCase(TestCase):
 
         self.assertTrue(foundation.is_full, "Foundation should be considered full with 13 cards in each pile.")
 
+    @staticmethod
+    def _get_foundation_components(foundation):
+        keys = set(map(str, foundation.piles.keys()))
+        hearts = list(map(str, foundation.piles[Suit.Hearts]))
+        clubs = list(map(str, foundation.piles[Suit.Clubs]))
+        diamonds = list(map(str, foundation.piles[Suit.Diamonds]))
+        spades = list(map(str, foundation.piles[Suit.Spades]))
+        undo_stack = list(map(lambda u: {'action': u.function.__name__, 'args': u.args}, foundation.undo_stack))
+        return (keys, hearts, clubs, diamonds, spades, undo_stack)
+
+    def test_dump(self):
+        foundation = Foundation()
+        for suit, pip in product(Suit, [Pip.Ace, Pip.Two, Pip.Three, Pip.Four, Pip.Five, Pip.Six, Pip.Seven, Pip.Eight,
+                                        Pip.Nine, Pip.Ten, Pip.Jack, Pip.Queen, Pip.King]):
+            foundation.put(Card(pip, suit, True))
+
+        dump = foundation.dump()
+        (keys, hearts, clubs, diamonds, spades, undo_stack) = self._get_foundation_components(foundation)
+        self.assertSetEqual(keys, set(dump["piles"].keys()))
+        self.assertListEqual(hearts, dump["piles"][Suit.Hearts.value])
+        self.assertListEqual(clubs, dump["piles"][Suit.Clubs.value])
+        self.assertListEqual(diamonds, dump["piles"][Suit.Diamonds.value])
+        self.assertListEqual(spades, dump["piles"][Suit.Spades.value])
+        self.assertListEqual(undo_stack, dump["undo_stack"])
+
+    def test_load(self):
+        # TODO: externalize this fixture
+        dump = {"piles": {"♠": [], "♦": ["A♦", "2♦", "3♦"], "♣": [], "♥": ["A♥"]},
+                "undo_stack": [{"action": "undo_put", "args": ["♥"]}, {"action": "undo_put", "args": ["♦"]},
+                               {"action": "undo_put", "args": ["♦"]}, {"action": "undo_put", "args": ["♦"]}]}
+
+        foundation = Foundation(foundation_dump=dump)
+        (keys, hearts, clubs, diamonds, spades, undo_stack) = self._get_foundation_components(foundation)
+
+        self.assertSetEqual(set(map(str, foundation.piles.keys())), set(dump["piles"].keys()))
+        self.assertListEqual(list(map(str, foundation.piles[Suit.Hearts])), dump["piles"][Suit.Hearts.value])
+        self.assertListEqual(list(map(str, foundation.piles[Suit.Clubs])), dump["piles"][Suit.Clubs.value])
+        self.assertListEqual(list(map(str, foundation.piles[Suit.Diamonds])), dump["piles"][Suit.Diamonds.value])
+        self.assertListEqual(list(map(str, foundation.piles[Suit.Spades])), dump["piles"][Suit.Spades.value])
+        self.assertListEqual(dump["undo_stack"], undo_stack)
+
     def test_undo_put(self):
         pass  # TODO: implement
 

--- a/test/test_klondike_game.py
+++ b/test/test_klondike_game.py
@@ -416,8 +416,56 @@ class KlondikeGameTestCase(TestCase):
 
     def test_dump(self):
         klondike = KlondikeGame()
-        game_dump = klondike.dump()
-        self.assertIsInstance(game_dump, dict, "Klondike dump should be a dict.")
+        piles = [
+            ["K♣", "Q♥", "J♣", "10♥", "9♣"],
+            ["K♦"],
+            ["|A♣", "|2♣", "10♦"],
+            [],
+            ["|4♣", "|6♥", "|8♦", "10♣", "9♦", "8♠", "7♦", "6♠"],
+            ["|3♣", "K♠", "Q♦"],
+            ["|9♥", "|5♦", "|3♠", "|7♣", "|8♣", "|K♥", "7♠", "6♦", "5♠", "4♥"]
+        ]
+        klondike.tableau.piles = list(map(lambda p: list(map(Card.parse_card, p)), piles))
+        klondike.select_tableau(0, 2, 5)
+        self.assertEqual(len(klondike.undo_stack), 1, "There should be exactly 1 undo action in the game.")
+        undo_stack = list(map(lambda u: {'action': u.function.__name__, 'args': u.args}, klondike.undo_stack))
+
+        dump = klondike.dump()
+        self.assertEqual(dump["score"], klondike.score)
+        self.assertListEqual(dump["waste"], klondike.waste)
+        self.assertListEqual(dump["undo_stack"], undo_stack)
+        # Don't bother with equivalence testing, just make sure these objects exist and aren't empty
+        self.assertTrue(dump["stock"])
+        self.assertTrue(dump["foundation"])
+        self.assertTrue(dump["tableau"])
+
+    def test_load(self):
+        dump = {"score": 0,
+                "stock": {"num_decks": 1, "num_jokers": 0, "is_shuffled": True,
+                          "cards": ["|3♥", "|K♠", "|A♠", "|4♥", "|9♣", "|6♦", "|Q♠", "|4♣", "|3♣", "|9♠",
+                                    "|8♥", "|4♠", "|5♥", "|J♣", "|2♣", "|K♥", "|5♠", "|3♠", "|6♥", "|K♣",
+                                    "|6♣", "|Q♣", "|7♥", "|3♦"]},
+                "waste": [],
+                "foundation": {"piles": {"♠": [], "♦": [], "♣": [], "♥": []}, "undo_stack": []},
+                "tableau": {
+                    "piles": [["K♣", "Q♥"], ["K♦"], ["|A♣", "|2♣", "10♦"], [],
+                              ["|4♣", "|6♥", "|8♦", "10♣", "9♦", "8♠", "7♦", "6♠"],
+                              ["|3♣", "K♠", "Q♦", "J♣", "10♥", "9♣"],
+                              ["|9♥", "|5♦", "|3♠", "|7♣", "|8♣", "|K♥", "7♠", "6♦", "5♠", "4♥"]],
+                    "undo_stack": [{"action": "undo_get", "args": [0, ["J♣", "10♥", "9♣"], False]},
+                                   {"action": "undo_put", "args": [5, 3]}]},
+                "undo_stack": [{"action": "undo_select_tableau", "args": [False]}]}
+
+        klondike = KlondikeGame(game_dump=dump)
+        undo_stack = list(map(lambda u: {'action': u.function.__name__, 'args': u.args}, klondike.undo_stack))
+
+        self.assertEqual(dump["score"], klondike.score)
+        self.assertListEqual(dump["waste"], klondike.waste)
+        self.assertListEqual(dump["undo_stack"], undo_stack)
+        # Don't bother with equivalence testing, just make sure these objects exist and aren't empty
+        self.assertTrue(klondike.stock)
+        self.assertTrue(klondike.foundation)
+        self.assertTrue(klondike.tableau)
 
     def test_undo(self):
         pass  # TODO: implement

--- a/test/test_klondike_game.py
+++ b/test/test_klondike_game.py
@@ -414,10 +414,10 @@ class KlondikeGameTestCase(TestCase):
 
         self.assertTrue(klondike.foundation.is_full, "Foundation should be full.")
 
-    def test_state(self):
+    def test_dump(self):
         klondike = KlondikeGame()
-        state = klondike.state
-        self.assertIsInstance(state, dict, "Klondike state should be a dict.")
+        game_dump = klondike.dump()
+        self.assertIsInstance(game_dump, dict, "Klondike dump should be a dict.")
 
     def test_undo(self):
         pass  # TODO: implement

--- a/test/test_tableau.py
+++ b/test/test_tableau.py
@@ -162,6 +162,41 @@ class TableauTestCase(TestCase):
         result = tableau._conceal(6)
         self.assertFalse(result, "Conceal action should have returned False for a concealed card.")
 
+    def test_dump(self):
+        tableau = Tableau()
+        piles = [
+            ["K♣", "Q♥", "J♣", "10♥", "9♣"],
+            ["K♦"],
+            ["|A♣", "|2♣", "10♦"],
+            [],
+            ["|4♣", "|6♥", "|8♦", "10♣", "9♦", "8♠", "7♦", "6♠"],
+            ["|3♣", "K♠", "Q♦"],
+            ["|9♥", "|5♦", "|3♠", "|7♣", "|8♣", "|K♥", "7♠", "6♦", "5♠", "4♥"]
+        ]
+        tableau.piles = list(map(lambda p: list(map(Card.parse_card, p)), piles))
+        tableau.put(tableau.get(0, 2), 5)
+        self.assertEqual(len(tableau.undo_stack), 2, "There should be exactly 2 undo actions in the tableau.")
+        undo_stack = list(map(lambda u: {'action': u.function.__name__, 'args': u.args}, tableau.undo_stack))
+
+        dump = tableau.dump()
+        self.assertEqual(len(dump["piles"]), len(tableau.piles))
+        for pile_num, tableau_pile in enumerate(tableau.piles):
+            self.assertListEqual(list(map(str, tableau_pile)), dump["piles"][pile_num])
+        self.assertListEqual(dump["undo_stack"], undo_stack)
+
+    def test_load(self):
+        dump = {"piles": [["K♣", "Q♥"], ["K♦"], ["|A♣", "|2♣", "10♦"], [],
+                          ["|4♣", "|6♥", "|8♦", "10♣", "9♦", "8♠", "7♦", "6♠"], ["|3♣", "K♠", "Q♦", "J♣", "10♥", "9♣"],
+                          ["|9♥", "|5♦", "|3♠", "|7♣", "|8♣", "|K♥", "7♠", "6♦", "5♠", "4♥"]],
+                "undo_stack": [{"action": "undo_get", "args": [0, ["J♣", "10♥", "9♣"], False]},
+                               {"action": "undo_put", "args": [5, 3]}]}
+        tableau = Tableau(tableau_dump=dump)
+        undo_stack = list(map(lambda u: {'action': u.function.__name__, 'args': u.args}, tableau.undo_stack))
+        self.assertEqual(len(tableau.piles), len(dump["piles"]))
+        for pile_num, tableau_pile in enumerate(tableau.piles):
+            self.assertListEqual(list(map(str, tableau_pile)), dump["piles"][pile_num])
+        self.assertListEqual(dump["undo_stack"], undo_stack)
+
     def test_undo_put(self):
         pass  # TODO: implement
 


### PR DESCRIPTION
Closes GH-2.  All export/import logic has been refactored to use JSON instead of `dill`, and the dependency has been removed from `requirements.txt`.

This required also refactoring how undo actions were done resulting in a few important changes:

- Created `UndoAction` dataclass to contain serializable undo actions, side effect being that implementing classes don't need to use `partial`s.
- Combinator functions that reduced action complexity from multiple events to a single event
- The above allowed the `undo_stack` to contain lists of `UndoAction`s instead of lists of lists of them
- The simplified undo logic, while still untested at this point, will be much simpler to test because preconditions/postconditions will be discrete and variable based only on the combinator args.
- Refactored card string representations to always show the card pip and suit, with an optional `|` pipe character to represent reveal state.  The gameplay display logic to show `#` for concealed cards was moved to `KlondikeCmd`, and is strictly a last-mile display concern.