### PR TITLE
Undo coverage

### DIFF
--- a/pytience/games/solitaire/foundation.py
+++ b/pytience/games/solitaire/foundation.py
@@ -18,10 +18,9 @@ class Foundation(Undoable):
             self.piles: Dict[Suit, List[Card]] = {suit: [] for suit in suits}
             super().__init__()
 
-    def undo_get(self, suit: str, card: str):
-        _suit = Suit(suit)
+    def undo_get(self, card: str):
         _card = Card.parse_card(card)
-        pile = self.piles.get(_suit)
+        pile = self.piles.get(_card.suit)
         pile.append(_card)
 
     def get(self, suit: Suit) -> Card:
@@ -32,7 +31,7 @@ class Foundation(Undoable):
             raise NoCardsRemainingException('No foundation cards for suit {}'.format(suit))
 
         card = pile.pop()
-        self.undo_stack.append(UndoAction(self.undo_get, [str(suit), str(card)]))
+        self.undo_stack.append(UndoAction(self.undo_get, [str(card)]))
         return card
 
     def undo_put(self, suit: str):

--- a/test/test_foundation.py
+++ b/test/test_foundation.py
@@ -133,47 +133,14 @@ class FoundationTestCase(TestCase):
 
     def test_undo_put(self):
         foundation = Foundation()
-        self.assertEqual(sum(len(pile) for pile in foundation.piles.values()), 0, "New Foundation should be empty.")
-        self.assertEqual(len(foundation.undo_stack), 0, "New Foundation should have an empty undo_stack.")
-
-        # Try putting a card that won't fit
-        with self.assertRaises(IllegalFoundationBuildOrderException,
-                               msg="Should raise exception if the card won't fit in the foundation."):
-            foundation.put(Card(Pip.King, Suit.Diamonds, True))
-        self.assertEqual(sum(len(pile) for pile in foundation.piles.values()), 0, "Foundation should still be empty.")
-        self.assertEqual(len(foundation.undo_stack), 0, "Foundation should still have an empty undo_stack.")
-
-        # Try a card that actually fits
-        foundation.put(Card(Pip.Ace, Suit.Diamonds, True))
-        self.assertEqual(sum(len(pile) for pile in foundation.piles.values()), 1, "Foundation should have one card.")
-        self.assertEqual(len(foundation.undo_stack), 1, "Foundation should have 1 action in the undo_stack.")
-
-        foundation.undo()
-        self.assertEqual(sum(len(pile) for pile in foundation.piles.values()), 0, "Foundation should have no cards.")
-        self.assertEqual(len(foundation.undo_stack), 0, "Foundation should have no actions in the undo_stack.")
+        foundation.piles[Suit.Clubs].append(Card.parse_card("A♣"))
+        self.assertEqual(len(foundation.piles[Suit.Clubs]), 1)
+        foundation.undo_put(str(Suit.Clubs))
+        self.assertEqual(len(foundation.piles[Suit.Clubs]), 0)
 
     def test_undo_get(self):
         foundation = Foundation()
-        foundation.piles[Suit.Diamonds].append(Card(Pip.Ace, Suit.Diamonds, True))
-
-        self.assertEqual(sum(len(pile) for pile in foundation.piles.values()), 1, "Foundation should have one card.")
-        self.assertEqual(len(foundation.undo_stack), 0, "Foundation should have 0 actions in the undo_stack.")
-
-        # Try getting a card from an empty pile
-        with self.assertRaises(NoCardsRemainingException, msg="Should raise exception if the pile is empty."):
-            foundation.get(Suit.Hearts)
-
-        self.assertEqual(sum(len(pile) for pile in foundation.piles.values()), 1,
-                         "Foundation should still have one card.")
-        self.assertEqual(len(foundation.undo_stack), 0, "Foundation should still have 0 actions in the undo_stack.")
-
-        card = foundation.get(Suit.Diamonds)
-        self.assertEqual(sum(len(pile) for pile in foundation.piles.values()), 0,
-                         "Foundation should now be empty.")
-        self.assertEqual(len(foundation.undo_stack), 1, "Foundation should now have 1 action in the undo_stack.")
-
-        foundation.undo()
-        self.assertEqual(len(foundation.piles[Suit.Diamonds]), 1, "Diamond Foundation should have 1 card.")
-        self.assertEqual(len(foundation.undo_stack), 0, "Foundation should have no actions in the undo_stack.")
-        self.assertEqual(foundation.piles[Suit.Diamonds][0], card,
-                         "The undone card should be the same that was previously removed.")
+        self.assertEqual(len(foundation.piles[Suit.Clubs]), 0)
+        foundation.undo_get("A♣")
+        self.assertEqual(len(foundation.piles[Suit.Clubs]), 1)
+        self.assertEqual(str(foundation.piles[Suit.Clubs][0]), "A♣")

--- a/test/test_foundation.py
+++ b/test/test_foundation.py
@@ -132,7 +132,48 @@ class FoundationTestCase(TestCase):
         self.assertListEqual(dump["undo_stack"], undo_stack)
 
     def test_undo_put(self):
-        pass  # TODO: implement
+        foundation = Foundation()
+        self.assertEqual(sum(len(pile) for pile in foundation.piles.values()), 0, "New Foundation should be empty.")
+        self.assertEqual(len(foundation.undo_stack), 0, "New Foundation should have an empty undo_stack.")
+
+        # Try putting a card that won't fit
+        with self.assertRaises(IllegalFoundationBuildOrderException,
+                               msg="Should raise exception if the card won't fit in the foundation."):
+            foundation.put(Card(Pip.King, Suit.Diamonds, True))
+        self.assertEqual(sum(len(pile) for pile in foundation.piles.values()), 0, "Foundation should still be empty.")
+        self.assertEqual(len(foundation.undo_stack), 0, "Foundation should still have an empty undo_stack.")
+
+        # Try a card that actually fits
+        foundation.put(Card(Pip.Ace, Suit.Diamonds, True))
+        self.assertEqual(sum(len(pile) for pile in foundation.piles.values()), 1, "Foundation should have one card.")
+        self.assertEqual(len(foundation.undo_stack), 1, "Foundation should have 1 action in the undo_stack.")
+
+        foundation.undo()
+        self.assertEqual(sum(len(pile) for pile in foundation.piles.values()), 0, "Foundation should have no cards.")
+        self.assertEqual(len(foundation.undo_stack), 0, "Foundation should have no actions in the undo_stack.")
 
     def test_undo_get(self):
-        pass  # TODO: implement
+        foundation = Foundation()
+        foundation.piles[Suit.Diamonds].append(Card(Pip.Ace, Suit.Diamonds, True))
+
+        self.assertEqual(sum(len(pile) for pile in foundation.piles.values()), 1, "Foundation should have one card.")
+        self.assertEqual(len(foundation.undo_stack), 0, "Foundation should have 0 actions in the undo_stack.")
+
+        # Try getting a card from an empty pile
+        with self.assertRaises(NoCardsRemainingException, msg="Should raise exception if the pile is empty."):
+            foundation.get(Suit.Hearts)
+
+        self.assertEqual(sum(len(pile) for pile in foundation.piles.values()), 1,
+                         "Foundation should still have one card.")
+        self.assertEqual(len(foundation.undo_stack), 0, "Foundation should still have 0 actions in the undo_stack.")
+
+        card = foundation.get(Suit.Diamonds)
+        self.assertEqual(sum(len(pile) for pile in foundation.piles.values()), 0,
+                         "Foundation should now be empty.")
+        self.assertEqual(len(foundation.undo_stack), 1, "Foundation should now have 1 action in the undo_stack.")
+
+        foundation.undo()
+        self.assertEqual(len(foundation.piles[Suit.Diamonds]), 1, "Diamond Foundation should have 1 card.")
+        self.assertEqual(len(foundation.undo_stack), 0, "Foundation should have no actions in the undo_stack.")
+        self.assertEqual(foundation.piles[Suit.Diamonds][0], card,
+                         "The undone card should be the same that was previously removed.")

--- a/test/test_klondike_game.py
+++ b/test/test_klondike_game.py
@@ -348,7 +348,7 @@ class KlondikeGameTestCase(TestCase):
             klondike.select_foundation(Suit.Hearts)
 
         # valid pile with fit
-        klondike.foundation.piles[Suit.Hearts][-1] = Card.parse_card("5♥")
+        klondike.foundation.piles[Suit.Hearts] = [Card.parse_card("5♥")]
         self.assertEqual(len(klondike.foundation.piles[Suit.Hearts]), 1, "Heart pile should have 1 card.")
         self.assertEqual(len(klondike.tableau.piles[3]), 4, "Pile 3 should have 4 cards.")
         klondike.select_foundation(Suit.Hearts, 3)

--- a/test/test_klondike_game.py
+++ b/test/test_klondike_game.py
@@ -2,7 +2,8 @@ from unittest import TestCase
 from unittest.mock import patch
 import itertools
 
-from pytience.games.solitaire.klondike import KlondikeGame
+from pytience.games.solitaire.klondike import KlondikeGame, POINTS_TABLEAU_FOUNDATION, POINTS_WASTE_TABLEAU, \
+    POINTS_WASTE_FOUNDATION
 from pytience.cards.deck import Card, Pip, Suit
 from pytience.games.exception import IllegalMoveException
 from pytience.cards.exception import NoCardsRemainingException
@@ -467,5 +468,79 @@ class KlondikeGameTestCase(TestCase):
         self.assertTrue(klondike.foundation)
         self.assertTrue(klondike.tableau)
 
-    def test_undo(self):
-        pass  # TODO: implement
+    @patch('pytience.games.solitaire.foundation.Foundation.undo')
+    @patch('pytience.games.solitaire.tableau.Tableau.undo')
+    def test_undo_select_foundation(self, tableau_undo, foundation_undo):
+        klondike = KlondikeGame()
+        self.assertEqual(klondike.score, 0)
+        foundation_undo.assert_not_called()
+        tableau_undo.assert_not_called()
+        klondike.undo_select_foundation()
+        self.assertEqual(klondike.score, POINTS_TABLEAU_FOUNDATION)
+        foundation_undo.assert_called_once()
+        tableau_undo.assert_called_once()
+
+    @patch('pytience.games.solitaire.foundation.Foundation.undo')
+    @patch('pytience.games.solitaire.tableau.Tableau.undo')
+    def test_undo_select_waste(self, tableau_undo, foundation_undo):
+        klondike = KlondikeGame()
+        card_string = "K♣"
+        self.assertEqual(klondike.score, 0)
+        foundation_undo.assert_not_called()
+        tableau_undo.assert_not_called()
+        klondike.undo_select_waste(undo_foundation=True, card_string=card_string)
+        self.assertEqual(klondike.score, -POINTS_WASTE_FOUNDATION)
+        foundation_undo.assert_called_once()
+        tableau_undo.assert_not_called()
+
+        klondike = KlondikeGame()
+        klondike.undo_select_waste(undo_foundation=False, card_string=card_string)
+        self.assertEqual(klondike.score, -POINTS_WASTE_TABLEAU)
+        foundation_undo.assert_called_once()
+        tableau_undo.assert_called_once()
+
+    def test_undo_deal(self):
+        klondike = KlondikeGame()
+        klondike.waste.append(klondike.stock.deal().reveal())
+
+        self.assertEqual(len(klondike.stock.cards), 23)
+        self.assertEqual(len(klondike.waste), 1)
+
+        klondike.undo_deal(undo_replenish=False)
+        self.assertEqual(len(klondike.stock.cards), 24)
+        self.assertEqual(len(klondike.waste), 0)
+
+        klondike.waste.append(klondike.stock.deal().reveal())
+        klondike.undo_deal(undo_replenish=True)
+        self.assertEqual(len(klondike.stock.cards), 0)
+        self.assertEqual(len(klondike.waste), 24)
+
+    @patch('pytience.games.solitaire.foundation.Foundation.undo')
+    @patch('pytience.games.solitaire.tableau.Tableau.undo')
+    def test_undo_seek_tableau_to_foundation(self, tableau_undo, foundation_undo):
+        klondike = KlondikeGame()
+        self.assertEqual(klondike.score, 0)
+        foundation_undo.assert_not_called()
+        tableau_undo.assert_not_called()
+        klondike.undo_seek_tableau_to_foundation()
+        self.assertEqual(klondike.score, -POINTS_TABLEAU_FOUNDATION)
+        foundation_undo.assert_called_once()
+        tableau_undo.assert_called_once()
+
+    @patch('pytience.games.solitaire.foundation.Foundation.undo')
+    @patch('pytience.games.solitaire.tableau.Tableau.undo')
+    def test_undo_select_tableau(self, tableau_undo, foundation_undo):
+        klondike = KlondikeGame()
+        self.assertEqual(klondike.score, 0)
+        foundation_undo.assert_not_called()
+        tableau_undo.assert_not_called()
+
+        klondike.undo_select_tableau(undo_foundation=False)
+        self.assertEqual(klondike.score, 0)
+        foundation_undo.assert_not_called()
+        self.assertEqual(tableau_undo.call_count, 2)
+
+        klondike.undo_select_tableau(undo_foundation=True)
+        self.assertEqual(klondike.score, -POINTS_TABLEAU_FOUNDATION)
+        foundation_undo.assert_called_once()
+        self.assertEqual(tableau_undo.call_count, 3)

--- a/test/test_tableau.py
+++ b/test/test_tableau.py
@@ -198,10 +198,30 @@ class TableauTestCase(TestCase):
         self.assertListEqual(dump["undo_stack"], undo_stack)
 
     def test_undo_put(self):
-        pass  # TODO: implement
+        tableau = Tableau()
+        cards = ["|4♣", "|6♥", "|8♦", "10♣", "9♦", "8♠", "7♦", "6♠"]
+        tableau.piles[0] = list(map(Card.parse_card, cards))
 
-    def test_undo_get_with_reveal(self):
-        pass  # TODO: implement
+        self.assertEqual(len(tableau.piles[0]), 8)
+        tableau.undo_put(0, 4)
+        self.assertListEqual(list(map(str, tableau.piles[0])), cards[:4])
 
-    def test_undo_get_without_reveal(self):
-        pass  # TODO: implement
+    def test_undo_get(self):
+        tableau = Tableau()
+        remaining_cards = ["|4♣", "|6♥", "|8♦", "10♣"]
+        gotten_card_strings = ["9♦", "8♠", "7♦", "6♠"]
+        tableau.piles[0] = list(map(Card.parse_card, remaining_cards))
+
+        self.assertEqual(len(tableau.piles[0]), 4)
+        self.assertTrue(tableau.piles[0][3].is_revealed)
+
+        # First undo it without re-concealing the top card
+        tableau.undo_get(0, gotten_card_strings, False)
+        self.assertEqual(len(tableau.piles[0]), 8)
+        self.assertTrue(tableau.piles[0][3].is_revealed)
+
+        tableau.piles[0] = list(map(Card.parse_card, remaining_cards))
+        tableau.undo_get(0, gotten_card_strings, True)
+        self.assertEqual(len(tableau.piles[0]), 8)
+        self.assertFalse(tableau.piles[0][3].is_revealed)
+


### PR DESCRIPTION
Added test coverage for all undo functions in `Foundation`, `Tableau`, and `KlondikeGame`.